### PR TITLE
Fixing how Stereotypes and Profiles are identified and consumed by Player Piano

### DIFF
--- a/ingrid/src/model_processing/patterns/ActorContext.json
+++ b/ingrid/src/model_processing/patterns/ActorContext.json
@@ -66,7 +66,12 @@
     "Vertex Stereotypes": {
         "A_composite owner_component": null,
         "Atomic Thing": null,
-        "Composite Thing": "Block",
+        "Composite Thing": [
+            {
+                "profile": "SysML",
+                "stereotype": "Block"
+            }
+        ],
         "component": null,
         "composite owner": null
     }

--- a/ingrid/src/model_processing/patterns/ActorRefiner.json
+++ b/ingrid/src/model_processing/patterns/ActorRefiner.json
@@ -31,8 +31,18 @@
         "actor": null
     },
     "Vertex Stereotypes": {
-        "block": "Block",
-        "refiner": "Refine",
+        "block": [
+            {
+                "profile": "SysML",
+                "stereotype": "Block"
+            }
+        ],
+        "refiner": [
+            {
+                "profile": "SysML",
+                "stereotype": "Refine"
+            }
+        ],
         "actor": null
     }
 }

--- a/ingrid/src/model_processing/patterns/CapabilityImplementation.json
+++ b/ingrid/src/model_processing/patterns/CapabilityImplementation.json
@@ -215,7 +215,7 @@
         ],
         "func": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "ReferenceProperty"
             }
         ],
@@ -224,7 +224,7 @@
         "performed by": null,
         "performs": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "ReferenceProperty"
             }
         ],

--- a/ingrid/src/model_processing/patterns/Composition.json
+++ b/ingrid/src/model_processing/patterns/Composition.json
@@ -79,7 +79,7 @@
         ],
         "component": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "PartProperty"
             }
         ],

--- a/ingrid/src/model_processing/patterns/FunctionElaboration.json
+++ b/ingrid/src/model_processing/patterns/FunctionElaboration.json
@@ -81,7 +81,7 @@
         ],
         "component": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "PartProperty"
             }
         ],

--- a/ingrid/src/model_processing/patterns/FunctionImplementation.json
+++ b/ingrid/src/model_processing/patterns/FunctionImplementation.json
@@ -150,7 +150,7 @@
         "performed by": null,
         "performs": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "ReferenceProperty"
             }
         ]

--- a/ingrid/src/model_processing/patterns/InterfaceConnection.json
+++ b/ingrid/src/model_processing/patterns/InterfaceConnection.json
@@ -177,13 +177,13 @@
         ],
         "Comp A": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "PartProperty"
             }
         ],
         "Comp B": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "PartProperty"
             }
         ],

--- a/ingrid/src/model_processing/patterns/InterfaceDataFlow.json
+++ b/ingrid/src/model_processing/patterns/InterfaceDataFlow.json
@@ -254,14 +254,14 @@
         ],
         "Comp A": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "PartProperty"
             }
         ],
         "Comp A Context": null,
         "Comp B": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "PartProperty"
             }
         ],

--- a/ingrid/src/model_processing/patterns/InterfaceDelegation.json
+++ b/ingrid/src/model_processing/patterns/InterfaceDelegation.json
@@ -144,7 +144,7 @@
         ],
         "Comp A": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "PartProperty"
             }
         ],

--- a/ingrid/src/model_processing/patterns/Parametric.json
+++ b/ingrid/src/model_processing/patterns/Parametric.json
@@ -232,7 +232,7 @@
         ],
         "blockValue": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "ValueProperty"
             }
         ],
@@ -244,7 +244,7 @@
         ],
         "constUse": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "ConstraintProperty"
             }
         ],
@@ -252,7 +252,7 @@
         "context1": null,
         "value": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "ConstraintParameter"
             }
         ],

--- a/ingrid/src/model_processing/patterns/README.md
+++ b/ingrid/src/model_processing/patterns/README.md
@@ -66,12 +66,12 @@ Since both the UML-based modeling pattern and the spreadsheet template share the
         [
             "Graph Edge 1 source name",
             "Graph Edge 1 target name",
-          	"UML metaproperty"
+            "UML metaproperty"
         ],
         [
             "Graph Edge N source name",
             "Graph Edge N target name",
-          	"UML metaproperty"
+            "UML metaproperty"
         ]
     ],
     "Root Node": "Root Node name",
@@ -81,15 +81,20 @@ Since both the UML-based modeling pattern and the spreadsheet template share the
     },
     "Vertex Settings": {
         "Graph Node 1 name": {
-          	"pattern element UML metaproperty setting 1, e.g. 'aggregation : composite'":  "value",
+            "pattern element UML metaproperty setting 1, e.g. 'aggregation : composite'":  "value",
             "pattern element UML metaproperty setting N": "value2"
         },
         "Graph Node N name": null //use null type if no settings applied
         },
-  	"Vertex Stereotypes": {
-        "Graph Node 1 name": "pattern element applied stereotype name, e.g. Block",
+    "Vertex Stereotypes": {
+        "Graph Node 1 name":[
+            {
+                "profile": "name of profile with the applied stereotype, e.g. SysML",
+                "stereotype": "pattern element applied stereotype name, e.g. Block",
+            }
+        ],
         "Graph Node N name": null //use null type if no applied stereotypes
-  			//currently only supports one applied stereotype
+            //currently only supports one applied stereotype
     }
 }
 ```
@@ -164,13 +169,40 @@ The JSON for the Composition pattern is shown below:
     },
     "Vertex Stereotypes": {
         "A_composite owner_component": null,
-        "Atomic Thing": "Block",
-        "Composite Thing": "Block",
-        "component": "PartProperty",
+        "Atomic Thing": [
+            {
+                "profile": "SysML",
+                "stereotype": "Block"
+            }
+        ],
+        "Composite Thing": [
+            {
+                "profile": "SysML",
+                "stereotype": "Block"
+            }
+        ],
+        "component": [
+            {
+                "profile": "MD Customization for SysML::additional_stereotypes",
+                "stereotype": "PartProperty"
+            }
+        ],
         "composite owner": null
     }
 }
 ```
+
+## Applying Stereotypes
+
+(discuss how to apply stereotypes first)
+
+The stereotypes applied to an element are called out by profile and stereotype name. For example, see how the SysML "Block" stereotype is applied to "Atomic Thing" and "Composite Thing" in the Composition pattern (above). Using stereotype names in combination with full qualified profile names eliminates ambiguity when applying stereotypes.  For example, see how the "PartProperty" stereotype is applied to "component" in the Composition pattern (above). Since the "additional_stereotypes" profile name is not unique in MagicDraw/Cameo Systems Modeler-produced SysML models, the profile containing the "PartProperty" stereotype is called out with the full qualified name: "MD Customization for SysML::additional_stereotypes."
+
+Using a pattern successfully requires that all profiles used in the pattern are already available in the model through usages.
+
+### Limitations
+
+The intent of the JSON pattern format is to capture any UML-based modeling pattern, independent of the tool used to actually model elements with the pattern (e.g. Cameo Systems Modeler). However, implementation of the SysML v1.x metamodel varies between tools. Since Rapid Modeling Tools currently only support MagicDraw/Cameo Systems Modeler, the profiles and stereotypes shown are tool-specific. Future support of any other tools would require additional tool-specific information.
 
 ## Pattern Builder
 

--- a/ingrid/src/model_processing/patterns/RelSys.json
+++ b/ingrid/src/model_processing/patterns/RelSys.json
@@ -54,8 +54,13 @@
         "ucend": null
     },
     "Vertex Stereotypes": {
-        "usecase": "requirementUseCase",
-        "relsys": "Block",
+        "usecase": null,
+        "relsys": [
+            {
+                "profile": "SysML",
+                "stereotype": "Block"
+            }
+        ],
         "relation": null,
         "relsysend": null,
         "ucend": null

--- a/ingrid/src/model_processing/patterns/SystemIndexParts.json
+++ b/ingrid/src/model_processing/patterns/SystemIndexParts.json
@@ -150,7 +150,7 @@
         ],
         "component": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "PartProperty"
             }
         ],
@@ -169,7 +169,7 @@
         ],
         "spatial": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "ValueProperty"
             }
         ],

--- a/ingrid/src/model_processing/patterns/SystemParts.json
+++ b/ingrid/src/model_processing/patterns/SystemParts.json
@@ -81,7 +81,7 @@
         ],
         "component": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "PartProperty"
             }
         ],

--- a/ingrid/src/model_processing/patterns/SystemSpatialParts.json
+++ b/ingrid/src/model_processing/patterns/SystemSpatialParts.json
@@ -150,7 +150,7 @@
         ],
         "component": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "PartProperty"
             }
         ],
@@ -169,7 +169,7 @@
         ],
         "spatial": [
             {
-                "profile": "SysML",
+                "profile": "MD Customization for SysML::additional_stereotypes",
                 "stereotype": "ValueProperty"
             }
         ],

--- a/ingrid/src/model_processing/patterns/UCElements.json
+++ b/ingrid/src/model_processing/patterns/UCElements.json
@@ -85,11 +85,26 @@
     },
     "Vertex Stereotypes": {
         "A_composite owner_component": null,
-        "Atomic Thing": "Block",
-        "Composite Thing": "Block",
-        "component": "PartProperty",
+        "Atomic Thing": [
+            {
+                "profile": "SysML",
+                "stereotype": "Block"
+            }  
+        ],
+        "Composite Thing": [
+            {
+                "profile": "SysML",
+                "stereotype": "Block"
+            }  
+        ],
+        "component": [
+            {
+                "profile": "MD Customization for SysML::additional_stereotypes",
+                "stereotype": "PartProperty"
+            }  
+        ],
         "composite owner": null,
-        "element": "requirementUseCase",
+        "element": null,
         "activity": null
     }
 }

--- a/ingrid/src/model_processing/patterns/UCOverview.json
+++ b/ingrid/src/model_processing/patterns/UCOverview.json
@@ -64,8 +64,13 @@
         "ucend": null
     },
     "Vertex Stereotypes": {
-        "context": "Block",
-        "usecase": "requirementUseCase",
+        "context": [
+            {
+                "profile": "SysML",
+                "stereotype": "Block"
+            }
+        ],
+        "usecase": null,
         "actor": null,
         "relation": null,
         "actorend": null,

--- a/ingrid/src/model_processing/patterns/UCTriggers.json
+++ b/ingrid/src/model_processing/patterns/UCTriggers.json
@@ -34,7 +34,7 @@
         "trigger": null
     },
     "Vertex Stereotypes": {
-        "usecase": "requirementUseCase",
+        "usecase": null,
         "activity": null,
         "trigger": null
     }

--- a/player-piano/player-piano-script.groovy
+++ b/player-piano/player-piano-script.groovy
@@ -1377,27 +1377,27 @@ finally {
 	// uncomment below to expose detailed logs
 	live_log.log('Execution steps:');
 	for (entry in execution_status_log) {
-		 live_log.log(entry);
+		 //live_log.log(entry);
 	}
 	live_log.log('Elements processed:');
 	for (entry in command_processing_log) {
-		 live_log.log(entry);
+		 //live_log.log(entry);
 	}
 	live_log.log('Element creation commands:');
 	for (entry in create_log) {
-		 live_log.log(entry);
+		 //live_log.log(entry);
 	}
 	live_log.log('Relationship replace commands:');
 	for (entry in replace_log) {
-		 live_log.log(entry);
+		 //live_log.log(entry);
 	}
 	live_log.log('Element rename commands:');
 	for (entry in rename_log) {
-		 live_log.log(entry);
+		 //live_log.log(entry);
 	}
 	live_log.log('Verification Details:');
 	for (entry in verification_log) {
-		live_log.log(entry);
+		//live_log.log(entry);
 	}
 
 	// render created names and id's into a file for slotting into other files

--- a/player-piano/player-piano-script.groovy
+++ b/player-piano/player-piano-script.groovy
@@ -45,6 +45,9 @@ try {
 	live_log = live_app.getGUILog();
 	live_project = live_app.getProject();
 
+	//grab all profiles in the project to help with identifying stereotypes
+	all_profiles = StereotypesHelper.getAllProfiles(live_project)
+
 	// dictionary to hold the ids discovered as we go
 	temp_ids = {};
 	temp_elements = {};
@@ -57,6 +60,7 @@ try {
 	assocs_to_clean = [];
 
 	create_list = [];
+
 
 	// try to make the element picker
 	try {
@@ -1180,10 +1184,27 @@ try {
 								new_stereo.each { stereo_dict ->
 									//get stereotype
 									stereo_name = stereo_dict['stereotype']
-									//lookup profile from the given id
-									profile = live_project.getElementByID(stereo_dict['profile'])
+									//lookup profile from the given name
+									profile_name = stereo_dict['profile']
+									profile = null
+									all_profiles.each { prof ->
+										if(prof.getName() == profile_name) {
+											profile = prof
+										} else if(prof.getQualifiedName() == profile_name) {
+											profile = prof
+										}
+									}
+									// add in logging info as well to help catch if stereotypes/profiles are not found successfully
+									if(profile == null) {
+										execution_status_log.add('Profile: "' + profile_name + 
+											'" not found while attempting to apply stereotype: "' + stereo_name)
+										execution_status_log.add('Verify that the correct profile name or qualified name is populated '+
+											' for the stereotype in the input file. Profiles with non-unique names' +
+											' should be idenfied by their qualified name.')
+									}
 									//get the stereotype object to apply
-									apply_stereo = StereotypesHelper.getStereotype(live_project, stereo_name, profile)
+									apply_stereo = StereotypesHelper.getStereotype(live_project, stereo_name, profile) 
+
 									//add the stereotype to the list of classifiers for the applied stereotype instance
 									class_list.add(apply_stereo)
 
@@ -1356,27 +1377,27 @@ finally {
 	// uncomment below to expose detailed logs
 	live_log.log('Execution steps:');
 	for (entry in execution_status_log) {
-		 //live_log.log(entry);
+		 live_log.log(entry);
 	}
 	live_log.log('Elements processed:');
 	for (entry in command_processing_log) {
-		 //live_log.log(entry);
+		 live_log.log(entry);
 	}
 	live_log.log('Element creation commands:');
 	for (entry in create_log) {
-		 //live_log.log(entry);
+		 live_log.log(entry);
 	}
 	live_log.log('Relationship replace commands:');
 	for (entry in replace_log) {
-		 //live_log.log(entry);
+		 live_log.log(entry);
 	}
 	live_log.log('Element rename commands:');
 	for (entry in rename_log) {
-		 //live_log.log(entry);
+		 live_log.log(entry);
 	}
 	live_log.log('Verification Details:');
 	for (entry in verification_log) {
-		//live_log.log(entry);
+		live_log.log(entry);
 	}
 
 	// render created names and id's into a file for slotting into other files


### PR DESCRIPTION
Updates Player Piano to identify profiles for stereotypes based on profile name or qualified name.
Updates all provided pattern files to use a consistent format for stereotype and profile information that is compatible with the Player Piano fix.

This addresses Issues #8, #9, and #17.
Most of Issue #21 is addressed by this fix except for any desired changes to the patterns [README](https://github.com/gtri/rapid-modeling-tools/tree/master/ingrid/src/model_processing/patterns) (or elsewhere) to document how patterns should be formatted 

Note that this fix is unrelated to the root cause of Issue #22 but is definitely required before #22 can actually be solved